### PR TITLE
Fix data source query encoding

### DIFF
--- a/src/datasources/insights/InsightsDataSource.ts
+++ b/src/datasources/insights/InsightsDataSource.ts
@@ -14,7 +14,7 @@ export class NewrelicInsightsDataSource {
   private doInsightsRequest(options: any, maxRetries = 1) {
     const queryParams = Object.keys(options)
       .filter(k => ['nrql'].indexOf(k) > -1)
-      .map(k => `${k}=${encodeURI(options[k])}`)
+      .map(k => `${k}=${encodeURIComponent(options[k])}`)
       .join('&');
     return this.backendSrv
       .datasourceRequest({

--- a/src/datasources/insights/tests/QueryEncoding.spec.ts
+++ b/src/datasources/insights/tests/QueryEncoding.spec.ts
@@ -1,0 +1,19 @@
+import { ctx, getInsightsQueryOptions, CONFIG } from './index';
+
+const query = `SELECT count(*) + 1 - 1 * 100 / 2 as 'Number of orders' FROM MobileEvent WHERE EventName = 'CreateOrder' TIMESERIES`;
+
+describe('Query Encoding', () => {
+  beforeEach(() => {
+    ctx.backendSrv.datasourceRequest = jest.fn().mockResolvedValue({});
+    ctx.templateSrv.replace = arg => arg;
+  });
+  it('should URL Encode queries', () => {
+    return ctx.ds.query(getInsightsQueryOptions([query], 'timeseries')).then(() => {
+      expect(ctx.backendSrv.datasourceRequest).toBeCalledWith(
+        expect.objectContaining({
+          url: expect.stringContaining(encodeURIComponent(query)),
+        })
+      );
+    });
+  });
+});


### PR DESCRIPTION
To prevent `+` (for example) from being removed from query